### PR TITLE
[Update] Replace lookup argument based range checks with R1CS

### DIFF
--- a/zprize/Cargo.lock
+++ b/zprize/Cargo.lock
@@ -1486,7 +1486,7 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-algorithms"
-version = "1.6.0"
+version = "1.4.0"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -1497,7 +1497,6 @@ dependencies = [
  "hex",
  "indexmap 2.0.2",
  "itertools 0.11.0",
- "lazy_static",
  "num-traits",
  "parking_lot",
  "rand 0.8.5",
@@ -1516,7 +1515,7 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit"
-version = "1.6.0"
+version = "1.4.0"
 dependencies = [
  "snarkvm-circuit-account",
  "snarkvm-circuit-algorithms",
@@ -1529,7 +1528,7 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-account"
-version = "1.6.0"
+version = "1.4.0"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-network",
@@ -1539,7 +1538,7 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-algorithms"
-version = "1.6.0"
+version = "1.4.0"
 dependencies = [
  "snarkvm-circuit-types",
  "snarkvm-console-algorithms",
@@ -1548,7 +1547,7 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-collections"
-version = "1.6.0"
+version = "1.4.0"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-types",
@@ -1557,7 +1556,7 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-environment"
-version = "1.6.0"
+version = "1.4.0"
 dependencies = [
  "indexmap 2.0.2",
  "itertools 0.11.0",
@@ -1575,11 +1574,11 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-environment-witness"
-version = "1.6.0"
+version = "1.4.0"
 
 [[package]]
 name = "snarkvm-circuit-network"
-version = "1.6.0"
+version = "1.4.0"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-collections",
@@ -1589,7 +1588,7 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-program"
-version = "1.6.0"
+version = "1.4.0"
 dependencies = [
  "paste",
  "snarkvm-circuit-account",
@@ -1603,7 +1602,7 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-types"
-version = "1.6.0"
+version = "1.4.0"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-address",
@@ -1617,7 +1616,7 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-types-address"
-version = "1.6.0"
+version = "1.4.0"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -1629,7 +1628,7 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-types-boolean"
-version = "1.6.0"
+version = "1.4.0"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-console-types-boolean",
@@ -1637,7 +1636,7 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-types-field"
-version = "1.6.0"
+version = "1.4.0"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -1646,7 +1645,7 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-types-group"
-version = "1.6.0"
+version = "1.4.0"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -1657,7 +1656,7 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-types-integers"
-version = "1.6.0"
+version = "1.4.0"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -1668,7 +1667,7 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-types-scalar"
-version = "1.6.0"
+version = "1.4.0"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -1678,7 +1677,7 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-types-string"
-version = "1.6.0"
+version = "1.4.0"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -1689,7 +1688,7 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console"
-version = "1.6.0"
+version = "1.4.0"
 dependencies = [
  "snarkvm-console-account",
  "snarkvm-console-algorithms",
@@ -1701,7 +1700,7 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-account"
-version = "1.6.0"
+version = "1.4.0"
 dependencies = [
  "bs58",
  "snarkvm-console-network",
@@ -1711,7 +1710,7 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-algorithms"
-version = "1.6.0"
+version = "1.4.0"
 dependencies = [
  "blake2s_simd",
  "smallvec",
@@ -1723,7 +1722,7 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-collections"
-version = "1.6.0"
+version = "1.4.0"
 dependencies = [
  "aleo-std",
  "rayon",
@@ -1733,7 +1732,7 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-network"
-version = "1.6.0"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "indexmap 2.0.2",
@@ -1755,7 +1754,7 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-network-environment"
-version = "1.6.0"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "bech32",
@@ -1772,7 +1771,7 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-program"
-version = "1.6.0"
+version = "1.4.0"
 dependencies = [
  "enum-iterator",
  "enum_index",
@@ -1793,7 +1792,7 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-types"
-version = "1.6.0"
+version = "1.4.0"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-address",
@@ -1807,7 +1806,7 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-types-address"
-version = "1.6.0"
+version = "1.4.0"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -1817,14 +1816,14 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-types-boolean"
-version = "1.6.0"
+version = "1.4.0"
 dependencies = [
  "snarkvm-console-network-environment",
 ]
 
 [[package]]
 name = "snarkvm-console-types-field"
-version = "1.6.0"
+version = "1.4.0"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -1833,7 +1832,7 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-types-group"
-version = "1.6.0"
+version = "1.4.0"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -1843,7 +1842,7 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-types-integers"
-version = "1.6.0"
+version = "1.4.0"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -1853,7 +1852,7 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-types-scalar"
-version = "1.6.0"
+version = "1.4.0"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -1863,7 +1862,7 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-types-string"
-version = "1.6.0"
+version = "1.4.0"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -1873,7 +1872,7 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-curves"
-version = "1.6.0"
+version = "1.4.0"
 dependencies = [
  "rand 0.8.5",
  "rayon",
@@ -1886,7 +1885,7 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-fields"
-version = "1.6.0"
+version = "1.4.0"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -1902,7 +1901,7 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-parameters"
-version = "1.6.0"
+version = "1.4.0"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -1926,7 +1925,7 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-utilities"
-version = "1.6.0"
+version = "1.4.0"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -1946,7 +1945,7 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-utilities-derives"
-version = "1.6.0"
+version = "1.4.0"
 dependencies = [
  "proc-macro2",
  "quote 1.0.40",

--- a/zprize/src/emulated_field.rs
+++ b/zprize/src/emulated_field.rs
@@ -364,7 +364,7 @@ impl EmulatedField {
         Env::assert_eq(&rlp, &F::one());
 
         /*
-        3. Apply multiplication gates and addition gates to evaluate t he following intermediate products mod 2**t
+        3. Apply multiplication gates and addition gates to evaluate the following intermediate products mod 2**t
             *) t_0 = a_0b_0 + q_0p'_0 - bits [0, 2b+1]
             *) t_1 = a_0b_1 + a_1b_0 + q_0p'_1 + q_1p'_0 - bits [b, 3b+2]
             *) t_2 = a_0b_2 + a_1b_1 + a_2_b0 + q_0p'_2 + q_1p'_1 + q_2p'_0 [2b, 4b+3]

--- a/zprize/src/utils.rs
+++ b/zprize/src/utils.rs
@@ -98,8 +98,8 @@ pub fn to_bytes(v: &F, len: usize) -> Vec<F> {
 
 /* using lookup table to do the comparison */
 pub fn is_less_than(a: &F, b: &F, num_bytes: usize) -> Boolean<Circuit>{
-    let (a_bytes_circuit, a_bytes_console) = to_bytes_withv(a, num_bytes);
-    let (b_bytes_circuit, b_bytes_console) = to_bytes_withv(b, num_bytes);
+    to_bytes_withv(a, num_bytes);
+    to_bytes_withv(b, num_bytes);
     a.is_less_than(b)
 }
 
@@ -112,25 +112,16 @@ pub fn is_less_than_constant(a: &F, b: &F, len: usize) -> Boolean<Circuit> {
 
     let highv = high.eject_value().to_bytes_le().unwrap();
 
-    let mut ls = Boolean::new(Private, highv[0] < 1);
-    let max = Circuit::one() * COEFFS[0].deref();
-
-    let table_index = 0usize;
-    // Circuit::enforce_lookup(|| (&high, max, &ls, table_index));
-
-    ls
+    let high_bit = F::new(high.eject_mode(), snarkvm_console::types::Field::from_u8(highv[0]);
+    high_bit.is_equal(&F::zero())
 }
 
 pub fn is_less_than_limb(a: &F, len: usize, pown: usize) -> Boolean<Circuit> {
-    let (a_bytes, a_vals) = to_bytes_withv(a, len);
+    let (a_bytes, _) = to_bytes_withv(a, len);
 
-    let mut ls = Boolean::new(Private, a_vals[len-1] < 2u8.pow(pown as u32));
-    let max = Circuit::one() * COEFFS[pown].deref();
-
-    let table_index = 0usize;
-    // Circuit::enforce_lookup(|| (a_bytes.get(len-1).unwrap(), max, &ls, table_index));
-
-    ls
+    // Ensure the max byte is less than b.
+    let b = F::new(Private, snarkvm_console::types::Field::from_u8(2u8.pow(pown as u32)));
+    a_bytes[len-1].is_less_than(&b));
 }
 
 pub fn splitField(v: &F, pos: usize, extra: usize) -> (F, F) {


### PR DESCRIPTION
## Motivation

Previously in the `SnarkVM` `ECDSA` zprize repo, several constraints were enforced via lookup arguments. Although support for lookup arguments within `SnarkVM` circuits constructions are an area of research in the `Aleo` community, it is unlikely that `SnarkVM` will support lookup arguments in production in the near term. Thus this for the purposes of building circuits for `ECDSA` verification over the `secp256k1` curve, the lookup argument based constraint enforcement for range checks in this experimental code should be replaced within SnarkVM's R1CS constraint checks. 

This PR implements `R1CS` enforcement of these constraints.

## Changelog
* The `is_less_than_constant` utility for enforcing limb values are less than the `secp256k1` base field modulus `P` is changed to R1CS constraint enforcement.
* The`is_less_than_limb` utility for  now implement R1CS based rangechecks.
* Minor code cleanup 

## Test Plan
* These utilities should have tests to ensure that these constraints are properly enforced

## Remaining Work
* Ensure any remaining lookup based constraint enforcement is updated to R1CS based constraints.