### PR TITLE
[Update] Use sha256 gadget to hash message

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -199,7 +199,7 @@ version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
- "generic-array",
+ "generic-array 0.14.7",
 ]
 
 [[package]]
@@ -428,7 +428,7 @@ version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "740fe28e594155f10cfc383984cbefd529d7396050557148f79cb0f621204124"
 dependencies = [
- "generic-array",
+ "generic-array 0.14.7",
  "rand_core 0.6.4",
  "subtle",
  "zeroize",
@@ -440,7 +440,7 @@ version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
- "generic-array",
+ "generic-array 0.14.7",
  "typenum",
 ]
 
@@ -518,9 +518,9 @@ dependencies = [
 
 [[package]]
 name = "ecdsa"
-version = "0.16.8"
+version = "0.16.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4b1e0c257a9e9f25f90ff76d7a68360ed497ee519c8e428d1825ef0000799d4"
+checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
 dependencies = [
  "der",
  "digest",
@@ -546,7 +546,7 @@ dependencies = [
  "crypto-bigint",
  "digest",
  "ff",
- "generic-array",
+ "generic-array 0.14.7",
  "group",
  "pkcs8",
  "rand_core 0.6.4",
@@ -669,6 +669,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "generic-array"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8c8444bc9d71b935156cc0ccab7f622180808af7867b1daae6547d773591703"
+dependencies = [
+ "typenum",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -744,6 +753,12 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hex-literal"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bcaaec4551594c969335c98c903c1397853d4198408ea609190f420500f6be71"
 
 [[package]]
 name = "hmac"
@@ -1394,7 +1409,7 @@ checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
 dependencies = [
  "base16ct",
  "der",
- "generic-array",
+ "generic-array 0.14.7",
  "pkcs8",
  "subtle",
  "zeroize",
@@ -1461,9 +1476,9 @@ dependencies = [
 
 [[package]]
 name = "signature"
-version = "2.1.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e1788eed21689f9cf370582dfc467ef36ed9c707f073528ddafa8d83e3b8500"
+checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
  "digest",
  "rand_core 0.6.4",
@@ -2521,8 +2536,12 @@ version = "0.1.0"
 dependencies = [
  "criterion",
  "crossbeam",
+ "crypto-common",
+ "digest",
  "ecdsa",
  "env_logger",
+ "generic-array 1.2.0",
+ "hex-literal",
  "k256",
  "lazy_static",
  "log",
@@ -2534,6 +2553,7 @@ dependencies = [
  "rust-crypto",
  "sha2",
  "sha3",
+ "signature",
  "snarkvm-algorithms",
  "snarkvm-circuit",
  "snarkvm-circuit-environment",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1486,7 +1486,7 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-algorithms"
-version = "1.6.0"
+version = "1.4.0"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -1497,7 +1497,6 @@ dependencies = [
  "hex",
  "indexmap 2.0.2",
  "itertools 0.11.0",
- "lazy_static",
  "num-traits",
  "parking_lot",
  "rand 0.8.5",
@@ -1516,7 +1515,7 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit"
-version = "1.6.0"
+version = "1.4.0"
 dependencies = [
  "snarkvm-circuit-account",
  "snarkvm-circuit-algorithms",
@@ -1529,7 +1528,7 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-account"
-version = "1.6.0"
+version = "1.4.0"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-network",
@@ -1539,7 +1538,7 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-algorithms"
-version = "1.6.0"
+version = "1.4.0"
 dependencies = [
  "snarkvm-circuit-types",
  "snarkvm-console-algorithms",
@@ -1548,7 +1547,7 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-collections"
-version = "1.6.0"
+version = "1.4.0"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-types",
@@ -1557,7 +1556,7 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-environment"
-version = "1.6.0"
+version = "1.4.0"
 dependencies = [
  "indexmap 2.0.2",
  "itertools 0.11.0",
@@ -1575,11 +1574,11 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-environment-witness"
-version = "1.6.0"
+version = "1.4.0"
 
 [[package]]
 name = "snarkvm-circuit-network"
-version = "1.6.0"
+version = "1.4.0"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-collections",
@@ -1589,7 +1588,7 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-program"
-version = "1.6.0"
+version = "1.4.0"
 dependencies = [
  "paste",
  "snarkvm-circuit-account",
@@ -1603,7 +1602,7 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-types"
-version = "1.6.0"
+version = "1.4.0"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-address",
@@ -1617,7 +1616,7 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-types-address"
-version = "1.6.0"
+version = "1.4.0"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -1629,7 +1628,7 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-types-boolean"
-version = "1.6.0"
+version = "1.4.0"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-console-types-boolean",
@@ -1637,7 +1636,7 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-types-field"
-version = "1.6.0"
+version = "1.4.0"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -1646,7 +1645,7 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-types-group"
-version = "1.6.0"
+version = "1.4.0"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -1657,7 +1656,7 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-types-integers"
-version = "1.6.0"
+version = "1.4.0"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -1668,7 +1667,7 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-types-scalar"
-version = "1.6.0"
+version = "1.4.0"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -1678,7 +1677,7 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-types-string"
-version = "1.6.0"
+version = "1.4.0"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -1689,7 +1688,7 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console"
-version = "1.6.0"
+version = "1.4.0"
 dependencies = [
  "snarkvm-console-account",
  "snarkvm-console-algorithms",
@@ -1701,7 +1700,7 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-account"
-version = "1.6.0"
+version = "1.4.0"
 dependencies = [
  "bs58",
  "snarkvm-console-network",
@@ -1711,7 +1710,7 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-algorithms"
-version = "1.6.0"
+version = "1.4.0"
 dependencies = [
  "blake2s_simd",
  "smallvec",
@@ -1723,7 +1722,7 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-collections"
-version = "1.6.0"
+version = "1.4.0"
 dependencies = [
  "aleo-std",
  "rayon",
@@ -1733,7 +1732,7 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-network"
-version = "1.6.0"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "indexmap 2.0.2",
@@ -1755,7 +1754,7 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-network-environment"
-version = "1.6.0"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "bech32",
@@ -1772,7 +1771,7 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-program"
-version = "1.6.0"
+version = "1.4.0"
 dependencies = [
  "enum-iterator",
  "enum_index",
@@ -1793,7 +1792,7 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-types"
-version = "1.6.0"
+version = "1.4.0"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-address",
@@ -1807,7 +1806,7 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-types-address"
-version = "1.6.0"
+version = "1.4.0"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -1817,14 +1816,14 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-types-boolean"
-version = "1.6.0"
+version = "1.4.0"
 dependencies = [
  "snarkvm-console-network-environment",
 ]
 
 [[package]]
 name = "snarkvm-console-types-field"
-version = "1.6.0"
+version = "1.4.0"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -1833,7 +1832,7 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-types-group"
-version = "1.6.0"
+version = "1.4.0"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -1843,7 +1842,7 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-types-integers"
-version = "1.6.0"
+version = "1.4.0"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -1853,7 +1852,7 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-types-scalar"
-version = "1.6.0"
+version = "1.4.0"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -1863,7 +1862,7 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-types-string"
-version = "1.6.0"
+version = "1.4.0"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -1873,7 +1872,7 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-curves"
-version = "1.6.0"
+version = "1.4.0"
 dependencies = [
  "rand 0.8.5",
  "rayon",
@@ -1886,7 +1885,7 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-fields"
-version = "1.6.0"
+version = "1.4.0"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -1902,7 +1901,7 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-parameters"
-version = "1.6.0"
+version = "1.4.0"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -1926,7 +1925,7 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-utilities"
-version = "1.6.0"
+version = "1.4.0"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -1946,7 +1945,7 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-utilities-derives"
-version = "1.6.0"
+version = "1.4.0"
 dependencies = [
  "proc-macro2",
  "quote 1.0.40",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1440,9 +1440,9 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.10.8"
+version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -2532,6 +2532,7 @@ dependencies = [
  "rand 0.8.5",
  "rayon",
  "rust-crypto",
+ "sha2",
  "sha3",
  "snarkvm-algorithms",
  "snarkvm-circuit",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1486,7 +1486,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-algorithms"
-version = "1.4.0"
+version = "1.6.0"
+source = "git+https://github.com/vicsn/snarkVM?rev=a64993f#a64993f6baa6a41a6541bb872b448a28bcbb5add"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -1497,6 +1498,7 @@ dependencies = [
  "hex",
  "indexmap 2.0.2",
  "itertools 0.11.0",
+ "lazy_static",
  "num-traits",
  "parking_lot",
  "rand 0.8.5",
@@ -1515,7 +1517,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit"
-version = "1.4.0"
+version = "1.6.0"
+source = "git+https://github.com/vicsn/snarkVM?rev=a64993f#a64993f6baa6a41a6541bb872b448a28bcbb5add"
 dependencies = [
  "snarkvm-circuit-account",
  "snarkvm-circuit-algorithms",
@@ -1528,7 +1531,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-account"
-version = "1.4.0"
+version = "1.6.0"
+source = "git+https://github.com/vicsn/snarkVM?rev=a64993f#a64993f6baa6a41a6541bb872b448a28bcbb5add"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-network",
@@ -1538,7 +1542,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-algorithms"
-version = "1.4.0"
+version = "1.6.0"
+source = "git+https://github.com/vicsn/snarkVM?rev=a64993f#a64993f6baa6a41a6541bb872b448a28bcbb5add"
 dependencies = [
  "snarkvm-circuit-types",
  "snarkvm-console-algorithms",
@@ -1547,7 +1552,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-collections"
-version = "1.4.0"
+version = "1.6.0"
+source = "git+https://github.com/vicsn/snarkVM?rev=a64993f#a64993f6baa6a41a6541bb872b448a28bcbb5add"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-types",
@@ -1556,7 +1562,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-environment"
-version = "1.4.0"
+version = "1.6.0"
+source = "git+https://github.com/vicsn/snarkVM?rev=a64993f#a64993f6baa6a41a6541bb872b448a28bcbb5add"
 dependencies = [
  "indexmap 2.0.2",
  "itertools 0.11.0",
@@ -1574,11 +1581,13 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-environment-witness"
-version = "1.4.0"
+version = "1.6.0"
+source = "git+https://github.com/vicsn/snarkVM?rev=a64993f#a64993f6baa6a41a6541bb872b448a28bcbb5add"
 
 [[package]]
 name = "snarkvm-circuit-network"
-version = "1.4.0"
+version = "1.6.0"
+source = "git+https://github.com/vicsn/snarkVM?rev=a64993f#a64993f6baa6a41a6541bb872b448a28bcbb5add"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-collections",
@@ -1588,7 +1597,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-program"
-version = "1.4.0"
+version = "1.6.0"
+source = "git+https://github.com/vicsn/snarkVM?rev=a64993f#a64993f6baa6a41a6541bb872b448a28bcbb5add"
 dependencies = [
  "paste",
  "snarkvm-circuit-account",
@@ -1602,7 +1612,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-types"
-version = "1.4.0"
+version = "1.6.0"
+source = "git+https://github.com/vicsn/snarkVM?rev=a64993f#a64993f6baa6a41a6541bb872b448a28bcbb5add"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-address",
@@ -1616,7 +1627,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-types-address"
-version = "1.4.0"
+version = "1.6.0"
+source = "git+https://github.com/vicsn/snarkVM?rev=a64993f#a64993f6baa6a41a6541bb872b448a28bcbb5add"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -1628,7 +1640,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-types-boolean"
-version = "1.4.0"
+version = "1.6.0"
+source = "git+https://github.com/vicsn/snarkVM?rev=a64993f#a64993f6baa6a41a6541bb872b448a28bcbb5add"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-console-types-boolean",
@@ -1636,7 +1649,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-types-field"
-version = "1.4.0"
+version = "1.6.0"
+source = "git+https://github.com/vicsn/snarkVM?rev=a64993f#a64993f6baa6a41a6541bb872b448a28bcbb5add"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -1645,7 +1659,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-types-group"
-version = "1.4.0"
+version = "1.6.0"
+source = "git+https://github.com/vicsn/snarkVM?rev=a64993f#a64993f6baa6a41a6541bb872b448a28bcbb5add"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -1656,7 +1671,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-types-integers"
-version = "1.4.0"
+version = "1.6.0"
+source = "git+https://github.com/vicsn/snarkVM?rev=a64993f#a64993f6baa6a41a6541bb872b448a28bcbb5add"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -1667,7 +1683,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-types-scalar"
-version = "1.4.0"
+version = "1.6.0"
+source = "git+https://github.com/vicsn/snarkVM?rev=a64993f#a64993f6baa6a41a6541bb872b448a28bcbb5add"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -1677,7 +1694,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-types-string"
-version = "1.4.0"
+version = "1.6.0"
+source = "git+https://github.com/vicsn/snarkVM?rev=a64993f#a64993f6baa6a41a6541bb872b448a28bcbb5add"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -1688,7 +1706,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console"
-version = "1.4.0"
+version = "1.6.0"
+source = "git+https://github.com/vicsn/snarkVM?rev=a64993f#a64993f6baa6a41a6541bb872b448a28bcbb5add"
 dependencies = [
  "snarkvm-console-account",
  "snarkvm-console-algorithms",
@@ -1700,7 +1719,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-account"
-version = "1.4.0"
+version = "1.6.0"
+source = "git+https://github.com/vicsn/snarkVM?rev=a64993f#a64993f6baa6a41a6541bb872b448a28bcbb5add"
 dependencies = [
  "bs58",
  "snarkvm-console-network",
@@ -1710,7 +1730,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-algorithms"
-version = "1.4.0"
+version = "1.6.0"
+source = "git+https://github.com/vicsn/snarkVM?rev=a64993f#a64993f6baa6a41a6541bb872b448a28bcbb5add"
 dependencies = [
  "blake2s_simd",
  "smallvec",
@@ -1722,7 +1743,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-collections"
-version = "1.4.0"
+version = "1.6.0"
+source = "git+https://github.com/vicsn/snarkVM?rev=a64993f#a64993f6baa6a41a6541bb872b448a28bcbb5add"
 dependencies = [
  "aleo-std",
  "rayon",
@@ -1732,7 +1754,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-network"
-version = "1.4.0"
+version = "1.6.0"
+source = "git+https://github.com/vicsn/snarkVM?rev=a64993f#a64993f6baa6a41a6541bb872b448a28bcbb5add"
 dependencies = [
  "anyhow",
  "indexmap 2.0.2",
@@ -1754,7 +1777,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-network-environment"
-version = "1.4.0"
+version = "1.6.0"
+source = "git+https://github.com/vicsn/snarkVM?rev=a64993f#a64993f6baa6a41a6541bb872b448a28bcbb5add"
 dependencies = [
  "anyhow",
  "bech32",
@@ -1771,7 +1795,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-program"
-version = "1.4.0"
+version = "1.6.0"
+source = "git+https://github.com/vicsn/snarkVM?rev=a64993f#a64993f6baa6a41a6541bb872b448a28bcbb5add"
 dependencies = [
  "enum-iterator",
  "enum_index",
@@ -1792,7 +1817,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-types"
-version = "1.4.0"
+version = "1.6.0"
+source = "git+https://github.com/vicsn/snarkVM?rev=a64993f#a64993f6baa6a41a6541bb872b448a28bcbb5add"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-address",
@@ -1806,7 +1832,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-types-address"
-version = "1.4.0"
+version = "1.6.0"
+source = "git+https://github.com/vicsn/snarkVM?rev=a64993f#a64993f6baa6a41a6541bb872b448a28bcbb5add"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -1816,14 +1843,16 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-types-boolean"
-version = "1.4.0"
+version = "1.6.0"
+source = "git+https://github.com/vicsn/snarkVM?rev=a64993f#a64993f6baa6a41a6541bb872b448a28bcbb5add"
 dependencies = [
  "snarkvm-console-network-environment",
 ]
 
 [[package]]
 name = "snarkvm-console-types-field"
-version = "1.4.0"
+version = "1.6.0"
+source = "git+https://github.com/vicsn/snarkVM?rev=a64993f#a64993f6baa6a41a6541bb872b448a28bcbb5add"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -1832,7 +1861,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-types-group"
-version = "1.4.0"
+version = "1.6.0"
+source = "git+https://github.com/vicsn/snarkVM?rev=a64993f#a64993f6baa6a41a6541bb872b448a28bcbb5add"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -1842,7 +1872,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-types-integers"
-version = "1.4.0"
+version = "1.6.0"
+source = "git+https://github.com/vicsn/snarkVM?rev=a64993f#a64993f6baa6a41a6541bb872b448a28bcbb5add"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -1852,7 +1883,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-types-scalar"
-version = "1.4.0"
+version = "1.6.0"
+source = "git+https://github.com/vicsn/snarkVM?rev=a64993f#a64993f6baa6a41a6541bb872b448a28bcbb5add"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -1862,7 +1894,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-types-string"
-version = "1.4.0"
+version = "1.6.0"
+source = "git+https://github.com/vicsn/snarkVM?rev=a64993f#a64993f6baa6a41a6541bb872b448a28bcbb5add"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -1872,7 +1905,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-curves"
-version = "1.4.0"
+version = "1.6.0"
+source = "git+https://github.com/vicsn/snarkVM?rev=a64993f#a64993f6baa6a41a6541bb872b448a28bcbb5add"
 dependencies = [
  "rand 0.8.5",
  "rayon",
@@ -1885,7 +1919,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-fields"
-version = "1.4.0"
+version = "1.6.0"
+source = "git+https://github.com/vicsn/snarkVM?rev=a64993f#a64993f6baa6a41a6541bb872b448a28bcbb5add"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -1901,7 +1936,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-parameters"
-version = "1.4.0"
+version = "1.6.0"
+source = "git+https://github.com/vicsn/snarkVM?rev=a64993f#a64993f6baa6a41a6541bb872b448a28bcbb5add"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -1925,7 +1961,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-utilities"
-version = "1.4.0"
+version = "1.6.0"
+source = "git+https://github.com/vicsn/snarkVM?rev=a64993f#a64993f6baa6a41a6541bb872b448a28bcbb5add"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -1945,7 +1982,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-utilities-derives"
-version = "1.4.0"
+version = "1.6.0"
+source = "git+https://github.com/vicsn/snarkVM?rev=a64993f#a64993f6baa6a41a6541bb872b448a28bcbb5add"
 dependencies = [
  "proc-macro2",
  "quote 1.0.40",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ snarkvm-utilities = { git = "https://github.com/vicsn/snarkVM" , rev = "a64993f"
 rand = "0.8.5"
 k256 = { version = "0.13", features = ["ecdsa"] }
 ecdsa = { version = "0.16", features = ["signing", "verifying"] }
+sha2 = "0.10.9"
 sha3 = "0.10"
 num-bigint = { version = "0.4", features = ["rand"] }
 num-integer = {version = "0.1"}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,15 +4,15 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-snarkvm-algorithms = { path = "../../snarkVM/algorithms" }
-snarkvm-circuit = {  path = "../../snarkVM/circuit" }
-snarkvm-console = { path = "../../snarkVM/console", features = [
+snarkvm-algorithms = { git = "https://github.com/vicsn/snarkVM" , rev = "a64993f"}
+snarkvm-circuit = { git = "https://github.com/vicsn/snarkVM" , rev = "a64993f"}
+snarkvm-console = { git = "https://github.com/vicsn/snarkVM" , rev = "a64993f" , features = [
     "types",
 ] }
-snarkvm-curves = { path = "../../snarkVM/curves" }
-snarkvm-circuit-environment = { path = "../../snarkVM/circuit/environment" }
-snarkvm-console-network = { path = "../../snarkVM/console/network" }
-snarkvm-utilities = { path = "../../snarkVM/utilities" }
+snarkvm-curves = { git = "https://github.com/vicsn/snarkVM" , rev = "a64993f" }
+snarkvm-circuit-environment = { git = "https://github.com/vicsn/snarkVM" , rev = "a64993f" }
+snarkvm-console-network = { git = "https://github.com/vicsn/snarkVM" , rev = "a64993f" }
+snarkvm-utilities = { git = "https://github.com/vicsn/snarkVM" , rev = "a64993f" }
 
 rand = "0.8.5"
 k256 = { version = "0.13", features = ["ecdsa"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,9 +24,14 @@ num-integer = {version = "0.1"}
 log = "0.4"
 rayon = "1.8"
 rust-crypto = "^0.2"
+crypto-common = "0.1.6"
 memory-stats = "1.0.0"
 
 crossbeam = "0.8.4"
+digest = "0.10.7"
+generic-array = "1.2.0"
+hex-literal = "1.0.0"
+signature = { version = "2.2.0", features = ["digest"] }
 
 [dependencies.lazy_static]
 version = "1.4"

--- a/src/api.rs
+++ b/src/api.rs
@@ -34,7 +34,7 @@ use crate::console;
 use crate::Tuples;
 
 use log::info;
-
+use crate::console::generate_signatures;
 //
 // Aliases
 // =======

--- a/src/circuit.rs
+++ b/src/circuit.rs
@@ -1,31 +1,29 @@
 use num_bigint::BigUint;
-use sha3::Keccak256;
 use snarkvm_circuit_environment::{prelude::PrimeField, Eject, Environment, Inject, Mode, Zero};
 use snarkvm_console_network::prelude::Itertools;
 use snarkvm_utilities::biginteger::BigInteger;
-use std::ops::{Add, Sub};
+use std::ops::{Add, Deref, Sub};
 
 // TODO: better to use AleoV0 or Circuit?
 use snarkvm_circuit::environment::prelude::num_traits::One;
-use snarkvm_circuit::{Circuit as Env, Field};
-use snarkvm_utilities::ToBytes;
+use snarkvm_circuit::{Circuit as Env, Field, sha2::Sha2_256, Boolean, Hash};
+use snarkvm_utilities::{FromBits, ToBits, ToBytes};
 //use snarkvm_circuit::{AleoV0 as Env, Field};
 
 use crate::ecc_secp256k1::Affine;
 use crate::emulated_field::{secp256k1_Fp, secp256k1_Fr, EmulatedField};
-use crate::keccak256;
-use crate::utils;
-use snarkvm_circuit_environment::FromBits;
 use snarkvm_circuit_environment::Mode::Private;
 
 use snarkvm_circuit::prelude::num_traits::FromPrimitive;
-
+use snarkvm_console_network::Network;
 //
 // Aliases
 // =======
 //
 
 type F = Field<Env>;
+
+type Bool = Boolean<Env>;
 
 //
 // Data structures
@@ -50,16 +48,30 @@ type F = Field<Env>;
 // we use a super naive way to encode things: 1 field = 1 byte.
 //
 
+///
+#[derive(Debug, Clone)]
 pub struct ECDSAPublicKey {
     bytes: Vec<F>,
 }
 
+/// The signature to be signed in byte representation.
+#[derive(Debug, Clone)]
 pub struct ECDSASignature {
     bytes: Vec<F>,
 }
 
+/// The message to be signed in circuit BE bit representation (so that it can be hashed by the Sha256 gadget).
+#[derive(Debug, Clone)]
 pub struct Message {
-    bytes: Vec<F>,
+    pub bits: Vec<Bool>,
+}
+
+impl Deref for Message {
+    type Target = Vec<Bool>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.bits
+    }
 }
 
 //
@@ -75,11 +87,12 @@ impl Inject for Message {
             // we'd have to constrain things to be bytes
             Mode::Private => unimplemented!(),
             Mode::Constant | Mode::Public => Message {
-                bytes: message
+                bits: message
                     .iter()
-                    .map(|b| {
-                        let f = snarkvm_console::types::Field::from_u8(*b);
-                        F::new(mode, f)
+                    .flat_map(|b| {
+                        b.to_bits_be().into_iter().map(|b| {
+                            Bool::new(mode, b)
+                        })
                     })
                     .collect_vec(),
             },
@@ -91,18 +104,19 @@ impl Eject for Message {
     type Primitive = Vec<u8>;
 
     fn eject_mode(&self) -> Mode {
-        self.bytes[0].eject_mode()
+        self.bits[0].eject_mode()
     }
 
     fn eject_value(&self) -> Self::Primitive {
-        self.bytes
+        self.bits
             .iter()
+            .chunks(8)
+            .into_iter()
             .map(|b| {
-                let f = b.eject_value();
-                let big = f.to_bigint();
-                let res = big.to_biguint().to_bytes_le();
-                assert_eq!(res.len(), 1);
-                res[0]
+                let bits = b.into_iter().map(|b| {
+                    b.eject_value()
+                }).collect::<Vec<bool>>();
+                u8::from_bits_be(&bits).unwrap()
             })
             .collect_vec()
     }
@@ -212,21 +226,17 @@ impl Eject for ECDSASignature {
 //
 /// Verifies a single ECDSA signature on a message.
 pub fn verify_one(_public_key: ECDSAPublicKey, _signature: ECDSASignature, msg: Message, compile_mode: bool) {
-    // don't add tables in constraint generation
-    // if compile_mode {
-    //     utils::add_tables();
-    //     keccak256::F64::add_lookup_tables();
-    // }
+    // Instantiate the sha2_256 hash function and hash the message.
+    let sha2 = Sha2_256::new();
+    let hash_bits = sha2.hash(&msg);
 
-    //keccak hash
-    let mut kk = keccak256::Keccak256::new();
-    kk.input(&msg.bytes);
+    // Get the hash as a BigUint so the emulated field can be created from all 256 bytes
+    // (SnarkVM fields would truncate the hash).
+    let (mode, z) = Message { bits: hash_bits }.eject();
+    let hash = BigUint::from_bytes_be(z.as_slice());
 
-    let mut hash = vec![F::zero(); 32];
-    kk.result(&mut hash.as_mut_slice());
-    hash.reverse();
-
-    let h = EmulatedField::from_F(hash.as_slice(), secp256k1_Fr);
+    // Create the emulated Fr field element from the hash.
+    let h = EmulatedField::from_BigUint(&hash, secp256k1_Fr.LIMB_BYTES_NUM, mode, secp256k1_Fr);
 
     //r,s
     let vr = _signature
@@ -308,4 +318,33 @@ pub fn verify_one(_public_key: ECDSAPublicKey, _signature: ECDSASignature, msg: 
 
     assert_eq!(mexp.x.value, r.value);
     EmulatedField::enforce_eq(&mexp.x, &r);
+}
+
+#[cfg(test)]
+mod tests {
+    use snarkvm_utilities::{TestRng, Uniform};
+    use super::*;
+
+    #[test]
+    fn test_msg_injection_and_ejection() {
+        // Generate 100 random 256-bit messages and test injection and ejection.
+        // This optimally should have deterministic test vectors.
+        for i in 0..100 {
+            let mut rng = TestRng::default();
+            let msg = (0..256)
+                .map(|_| u8::rand(&mut rng))
+                .collect::<Vec<u8>>();
+            let message = Message::new(Mode::Public, msg.clone());
+            assert_eq!(msg, message.eject_value());
+        }
+    }
+
+    #[test]
+    fn test_msg_layout() {
+        let mut rng = TestRng::default();
+        let msg = (0..256)
+            .map(|_| u8::rand(&mut rng))
+            .collect::<Vec<u8>>();
+        let message = Message::new(Mode::Public, msg.clone());
+    }
 }

--- a/src/circuit.rs
+++ b/src/circuit.rs
@@ -228,11 +228,15 @@ impl Eject for ECDSASignature {
 pub fn verify_one(_public_key: ECDSAPublicKey, _signature: ECDSASignature, msg: Message, compile_mode: bool) {
     // Instantiate the sha2_256 hash function and hash the message.
     let sha2 = Sha2_256::new();
-    let hash_bits = sha2.hash(&msg);
+    let intermediate_bits = sha2.hash(&msg);
+    let bits = sha2.hash(&intermediate_bits);
 
     // Get the hash as a BigUint so the emulated field can be created from all 256 bytes
     // (SnarkVM fields would truncate the hash).
-    let (mode, z) = Message { bits: hash_bits }.eject();
+    let (mode, z) = Message { bits }.eject();
+    println!("z: {:?}", z);
+
+
     let hash = BigUint::from_bytes_be(z.as_slice());
 
     // Create the emulated Fr field element from the hash.

--- a/src/console.rs
+++ b/src/console.rs
@@ -50,8 +50,12 @@ pub fn sample_pubkey_sig(msg: &[u8]) -> (ECDSAPublicKey, ECDSASignature) {
     let secret_key = k256::ecdsa::SigningKey::random(rng);
     let public_key = secret_key.verifying_key().clone();
 
+    let mut hasher = crate::double_sha256::DoubleSha256::new();
+    hasher.update(&msg);
+    println!("console hash {:?}", hasher.finalize());
+
     // hash bytes
-    let mut hasher = sha3::Keccak256::new();
+    let mut hasher = crate::double_sha256::DoubleSha256::new();
     hasher.update(&msg);
 
     // sign

--- a/src/console.rs
+++ b/src/console.rs
@@ -1,5 +1,5 @@
-use ecdsa::signature::DigestVerifier;
 use ecdsa::hazmat::bits2field;
+use ecdsa::signature::DigestVerifier;
 
 //use ecdsa::SigningKey;
 use k256::ecdsa::{Signature, SigningKey, VerifyingKey};
@@ -89,4 +89,12 @@ pub fn generate_signatures(msg_len: usize, num: usize) -> Vec<(VerifyingKey, Vec
     }
 
     res
+}
+
+pub fn double_sha256(data: impl AsRef<[u8]>) -> [u8; 32] {
+    let first = sha2::Sha256::digest(data.as_ref());
+    let second = sha2::Sha256::digest(&first);
+    let mut out = [0u8; 32];
+    out.copy_from_slice(&second);
+    out
 }

--- a/src/console.rs
+++ b/src/console.rs
@@ -74,7 +74,7 @@ pub fn generate_signatures(msg_len: usize, num: usize) -> Vec<(VerifyingKey, Vec
         //thread_rng().fill_bytes(&mut msg);
 
         // hash msg
-        let mut hasher = Keccak256::new();
+        let mut hasher = crate::double_sha256::DoubleSha256::new();
         hasher.update(&msg);
 
         //println!("keccark hash: {:?}", &hasher.clone().finalize());
@@ -82,19 +82,11 @@ pub fn generate_signatures(msg_len: usize, num: usize) -> Vec<(VerifyingKey, Vec
         // generate signature
         let (signature, _) = secret_key.sign_digest_recoverable(hasher.clone()).unwrap();
 
-        // verify the signature
-        assert!(public_key.verify_digest(hasher, &signature).is_ok());
+        // // verify the signature
+        // assert!(public_key.verify_digest(hasher, &signature).is_ok());
 
         res.push((public_key.clone(), msg, signature));
     }
 
     res
-}
-
-pub fn double_sha256(data: impl AsRef<[u8]>) -> [u8; 32] {
-    let first = sha2::Sha256::digest(data.as_ref());
-    let second = sha2::Sha256::digest(&first);
-    let mut out = [0u8; 32];
-    out.copy_from_slice(&second);
-    out
 }

--- a/src/double_sha256.rs
+++ b/src/double_sha256.rs
@@ -1,0 +1,99 @@
+use crypto_common::OutputSizeUser;
+use digest::consts::U32;
+use digest::generic_array::GenericArray;
+use digest::Digest;
+use sha2::Sha256; // Digest trait comes from sha2’s re-export
+
+/// Bitcoin-style *double* SHA-256: `SHA256(SHA256(data))`.
+#[derive(Clone, Default)]
+pub struct DoubleSha256 {
+    inner: Sha256, // first-round engine
+}
+
+impl OutputSizeUser for DoubleSha256 {
+    type OutputSize = U32;
+}
+
+impl<D> DigestVerifier<D, Signature> for 
+
+impl Digest for DoubleSha256 {
+    #[inline(always)]
+    fn new() -> Self {
+        Self::default()
+    }
+
+    /// Stream data into the *first* SHA-256 round.
+    #[inline(always)]
+    fn update(&mut self, data: impl AsRef<[u8]>) {
+        self.inner.update(data);
+    }
+
+    /// `SHA256(SHA256(data))`
+    #[inline(always)]
+    fn finalize(self) -> GenericArray<u8, Self::OutputSize> {
+        let first = self.inner.finalize(); // SHA256(data)
+        Sha256::digest(first) // SHA256(SHA256(data))
+    }
+
+    /// Same as `finalize`, but leave the hasher ready for new input.
+    #[inline(always)]
+    fn finalize_reset(&mut self) -> GenericArray<u8, Self::OutputSize> {
+        // `finalize_reset` clears `inner` for us, so we can re-use it.
+        let first = self.inner.finalize_reset();
+        Sha256::digest(first)
+    }
+
+    /// Clear internal state.
+    #[inline(always)]
+    fn reset(&mut self) {
+        self.inner.reset();
+    }
+
+    fn new_with_prefix(prefix: impl AsRef<[u8]>) -> Self {
+        todo!("DoubleSha256::new_with_prefix is not implemented yet")
+    }
+
+    fn chain_update(self, data: impl AsRef<[u8]>) -> Self
+    where
+        Self: Sized,
+    {
+        todo!("DoubleSha256::chain_update is not implemented yet")
+    }
+
+    fn finalize_into(self, _out: &mut GenericArray<u8, Self::OutputSize>) {
+        todo!("DoubleSha256::finalize_into is not implemented yet")
+    }
+
+    fn finalize_into_reset(&mut self, _out: &mut GenericArray<u8, Self::OutputSize>) {
+        todo!("DoubleSha256::finalize_into_reset is not implemented yet")
+    }
+
+    fn output_size() -> usize {
+        todo!("DoubleSha256::output_size is not implemented yet")
+    }
+
+    fn digest(data: impl AsRef<[u8]>) -> GenericArray<u8, Self::OutputSize> {
+        todo!("DoubleSha256::digest is not implemented yet")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::DoubleSha256;
+    use hex_literal::hex;
+    use sha2::Digest; // pulls in the same trait we just implemented
+
+    #[test]
+    fn abc_vector() {
+        let mut h = DoubleSha256::new();
+        h.update(b"abc");
+        let out = h.finalize();
+        let mut hash = [0u8; 32];
+        hash.copy_from_slice(&out);
+
+        assert_eq!(
+            hash,
+            hex!("4f8b42c22dd3729b519ba6f68d2da7cc5b2d606d05daed5ad5128cc03e6c6358")
+        );
+    }
+}

--- a/src/double_sha256.rs
+++ b/src/double_sha256.rs
@@ -14,8 +14,6 @@ impl OutputSizeUser for DoubleSha256 {
     type OutputSize = U32;
 }
 
-impl<D> DigestVerifier<D, Signature> for 
-
 impl Digest for DoubleSha256 {
     #[inline(always)]
     fn new() -> Self {

--- a/src/emulated_field.rs
+++ b/src/emulated_field.rs
@@ -364,7 +364,7 @@ impl EmulatedField {
         Env::assert_eq(&rlp, &F::one());
 
         /*
-        3. Apply multiplication gates and addition gates to evaluate t he following intermediate products mod 2**t
+        3. Apply multiplication gates and addition gates to evaluate the following intermediate products mod 2**t
             *) t_0 = a_0b_0 + q_0p'_0 - bits [0, 2b+1]
             *) t_1 = a_0b_1 + a_1b_0 + q_0p'_1 + q_1p'_0 - bits [b, 3b+2]
             *) t_2 = a_0b_2 + a_1b_1 + a_2_b0 + q_0p'_2 + q_1p'_1 + q_2p'_0 [2b, 4b+3]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,6 +22,7 @@ use snarkvm_curves::bls12_377::Bls12_377;
 pub mod api;
 pub mod circuit;
 pub mod console;
+pub mod double_sha256;
 pub mod ecc_secp256k1;
 pub mod emulated_field;
 pub mod keccak256;

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -112,7 +112,7 @@ pub fn is_less_than_constant(a: &F, b: &F, len: usize) -> Boolean<Circuit> {
 
     let highv = high.eject_value().to_bytes_le().unwrap();
 
-    let high_bit = F::new(high.eject_mode(), snarkvm_console::types::Field::from_u8(highv[0]);
+    let high_bit = F::new(high.eject_mode(), snarkvm_console::types::Field::from_u8(highv[0]));
     high_bit.is_equal(&F::zero())
 }
 
@@ -121,7 +121,7 @@ pub fn is_less_than_limb(a: &F, len: usize, pown: usize) -> Boolean<Circuit> {
 
     // Ensure the max byte is less than b.
     let b = F::new(Private, snarkvm_console::types::Field::from_u8(2u8.pow(pown as u32)));
-    a_bytes[len-1].is_less_than(&b));
+    a_bytes[len-1].is_less_than(&b)
 }
 
 pub fn splitField(v: &F, pos: usize, extra: usize) -> (F, F) {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -98,8 +98,8 @@ pub fn to_bytes(v: &F, len: usize) -> Vec<F> {
 
 /* using lookup table to do the comparison */
 pub fn is_less_than(a: &F, b: &F, num_bytes: usize) -> Boolean<Circuit>{
-    let (a_bytes_circuit, a_bytes_console) = to_bytes_withv(a, num_bytes);
-    let (b_bytes_circuit, b_bytes_console) = to_bytes_withv(b, num_bytes);
+    to_bytes_withv(a, num_bytes);
+    to_bytes_withv(b, num_bytes);
     a.is_less_than(b)
 }
 
@@ -112,25 +112,16 @@ pub fn is_less_than_constant(a: &F, b: &F, len: usize) -> Boolean<Circuit> {
 
     let highv = high.eject_value().to_bytes_le().unwrap();
 
-    let mut ls = Boolean::new(Private, highv[0] < 1);
-    let max = Circuit::one() * COEFFS[0].deref();
-
-    let table_index = 0usize;
-    // Circuit::enforce_lookup(|| (&high, max, &ls, table_index));
-
-    ls
+    let high_bit = F::new(high.eject_mode(), snarkvm_console::types::Field::from_u8(highv[0]);
+    high_bit.is_equal(&F::zero())
 }
 
 pub fn is_less_than_limb(a: &F, len: usize, pown: usize) -> Boolean<Circuit> {
-    let (a_bytes, a_vals) = to_bytes_withv(a, len);
+    let (a_bytes, _) = to_bytes_withv(a, len);
 
-    let mut ls = Boolean::new(Private, a_vals[len-1] < 2u8.pow(pown as u32));
-    let max = Circuit::one() * COEFFS[pown].deref();
-
-    let table_index = 0usize;
-    // Circuit::enforce_lookup(|| (a_bytes.get(len-1).unwrap(), max, &ls, table_index));
-
-    ls
+    // Ensure the max byte is less than b.
+    let b = F::new(Private, snarkvm_console::types::Field::from_u8(2u8.pow(pown as u32)));
+    a_bytes[len-1].is_less_than(&b));
 }
 
 pub fn splitField(v: &F, pos: usize, extra: usize) -> (F, F) {


### PR DESCRIPTION
## Motivation 

Bitcoin uses SHA2 to create ECDSA signatures over its UTXOs. To verify external Bitcoin ECDSA signatures, an implementation of a SHA2 gadget must be used to verify these signatures within a Varuna circuit. This gadget was implemented in a [SnarkVM fork](https://github.com/vicsn/snarkVM/tree/proof-of-reserves-btc). This PR pulls this work and implements it to enable verification of Bitcoin signatures.

## Changelog
* Changed the internal representation of the message type to `Vec<Bool>`
* Change Inject and Eject for the message type to take and return a Vec<u8>. A robust implementation would provide a circuit-level `from_bytes_le` and `from_bytes_be` to allow future users full imperative control over their endianness.
* Implements SHA2 hashing within the `verify_one` function.
* Instantiates the EmulatedField from a BigUint in order to preserve the information in `z = hash(m)` operation  as a native field element would truncate the bits.

## Test plan
* Several real world Bitcoin signatures should be inserted as test vectors to ensure the implementation of both the gadget and the internal representation of the message are correct.

## Remaining Work
* Audit the representation of the hash and message for correctness
* Add test vectors and tests to ensure the implementation is correct.